### PR TITLE
Save the keystore in localStorage

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -254,7 +254,7 @@ const ChoosePassword = (_: ChoosePasswordProps) => {
 	const canNext = showPrompt || passwordValid
 
 	const navigate = useNavigate()
-	const onNext = () => {
+	const onNext = async () => {
 		if (showPrompt) {
 			setShowPrompt(false)
 			return
@@ -264,13 +264,11 @@ const ChoosePassword = (_: ChoosePasswordProps) => {
 			return
 		}
 
-		;(async () => {
-			setLoading(true)
-			const wallet = Wallet.fromMnemonic(mnemonic.phrase)
-			setEncryptedWallet(await wallet.encrypt(passwords[0]))
-			navigate('/login/done')
-			setLoading(false)
-		})()
+		setLoading(true)
+		const wallet = Wallet.fromMnemonic(mnemonic.phrase)
+		setEncryptedWallet(await wallet.encrypt(passwords[0]))
+		navigate('/login/done')
+		setLoading(false)
 	}
 
 	return (

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,9 +6,45 @@ type Profile = {
 }
 
 type Store = {
-	address: string
-	mnemonic: Mnemonic
-	profile: Profile
+	address: string | undefined
+	mnemonic: Mnemonic | undefined
+	profile: Profile | undefined
+	encryptedWallet: string | undefined
 }
 
-export const { useStore, getStore, withStore } = createStore<Store>()
+function setLocalStore(key: string, value?: string) {
+	if (value) {
+		localStorage.setItem(key, value)
+	} else {
+		localStorage.removeItem(key)
+	}
+}
+
+function updateLocalStore(store: Store, prevStore: Store, key: keyof Store) {
+	if (store[key] !== prevStore[key]) {
+		setLocalStore(key, JSON.stringify(store[key]))
+	}
+}
+
+function readLocalStore<T>(key: string): T | undefined {
+	try {
+		const json = localStorage.getItem(key)
+		return json ? (JSON.parse(json) as T) : undefined
+	} catch (err) {
+		return undefined
+	}
+}
+
+export const { useStore, getStore, withStore } = createStore<Store>(
+	{
+		address: readLocalStore('address'),
+		mnemonic: undefined,
+		profile: readLocalStore('profile'),
+		encryptedWallet: readLocalStore('encryptedWallet'),
+	},
+	({ store, prevStore }) => {
+		updateLocalStore(store, prevStore, 'encryptedWallet')
+		updateLocalStore(store, prevStore, 'profile')
+		updateLocalStore(store, prevStore, 'address')
+	}
+)


### PR DESCRIPTION
Saves 3 variables to `localStorage`:
- `address`
- `profile`
- `encryptedWallet`

The `teaful` types part is admittedly a bit funky, but I think their types aren't quite perfect yet. It's coming in the next release (`0.11.0`) though hopefully.

The last step (encryption of the wallet) takes ages, so be patient!

Fixes #5.