### PR TITLE
fix: add `error-document` to `pr-preview`

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -41,3 +41,4 @@ jobs:
         uses: filoozom/swarm-actions/pr-preview@v0
         with:
           dir: ./dist
+          error-document: index.html


### PR DESCRIPTION
In theory this should make routing work for all routes on the version hosted on Swarm.