### PR TITLE
fix: use `Link` instead of `a` in `ButtonClose`

### DIFF
--- a/src/components/ButtonClose.tsx
+++ b/src/components/ButtonClose.tsx
@@ -1,14 +1,45 @@
-import { JSXInternal } from 'preact/src/jsx'
+import { Link } from '@reach/router'
+
+// Assets
 import close from '../assets/imgs/close.svg?url'
 import closeWhite from '../assets/imgs/closeWhite.svg?url'
 
-interface Props extends JSXInternal.HTMLAttributes<HTMLAnchorElement> {
+// Types
+import type { LinkProps } from '@reach/router'
+import type { JSXInternal } from 'preact/src/jsx'
+
+interface Props<TState>
+	extends Omit<LinkProps<TState>, 'ref' | 'to'>,
+		Pick<JSXInternal.HTMLAttributes<HTMLAnchorElement>, 'href' | 'ref'> {
 	variant?: 'light' | 'dark'
+	to?: LinkProps<TState>['to']
 }
 
-export function ButtonClose({ variant, ...other }: Props) {
+export function ButtonClose<TState>({
+	variant,
+	href,
+	to,
+	...other
+}: Props<TState>) {
+	const image = <img src={variant === 'light' ? closeWhite : close} />
+
+	if (to && href) {
+		console.warn('do not specify both `to` and `href`')
+		return null
+	}
+
+	if (to) {
+		return (
+			<Link role="button" to={to} {...other}>
+				{image}
+			</Link>
+		)
+	}
+
+	// NOTE: Is this fallback actually necessary?
+	// TODO: Remove?
 	return (
-		<a role="button" {...other}>
+		<a role="button" href={href} {...(other as unknown)}>
 			<img src={variant === 'light' ? closeWhite : close} />
 		</a>
 	)

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -7,7 +7,7 @@ type LoginProps = RouteComponentProps
 export const Login = (_: LoginProps) => (
 	<div class="bg-info create-account">
 		<div class="close">
-			<ButtonClose href={HOME} variant="light" />
+			<ButtonClose to={HOME} variant="light" />
 		</div>
 		<div class="container">
 			<main class=" flex-space">


### PR DESCRIPTION
Related: #40 